### PR TITLE
Add indentation to GPX output and use HTTPS for XSD

### DIFF
--- a/gpx.h
+++ b/gpx.h
@@ -39,12 +39,12 @@ int year,month,day,hour,minute,sec,sat;
 if(part==GPX_HEADER){ 
   y=0;
   i= sprintf(bufferTx,"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");y=y+i;
-  i= sprintf(&bufferTx[y],"<gpx version=\"1.0\" creator=\"ESP-GPS SW 5.75\"\n");y=y+i; 
-  i= sprintf(&bufferTx[y],"xmlns=\"http://www.topografix.com/GPX/1/0\"\n");y=y+i;
-  i= sprintf(&bufferTx[y],"xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n");y=y+i;
-  i= sprintf(&bufferTx[y],"xsi:schemaLocation=\"http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd\">\n");y=y+i; 
-  i= sprintf(&bufferTx[y],"<trk>\n");y=y+i;
-  i= sprintf(&bufferTx[y],"<trkseg>\n");y=y+i;
+  i= sprintf(&bufferTx[y],"<gpx version=\"1.0\" creator=\"ESP-GPS SW 5.75\" ");y=y+i;
+  i= sprintf(&bufferTx[y],"xmlns=\"http://www.topografix.com/GPX/1/0\" ");y=y+i;
+  i= sprintf(&bufferTx[y],"xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ");y=y+i;
+  i= sprintf(&bufferTx[y],"xsi:schemaLocation=\"http://www.topografix.com/GPX/1/0 https://www.topografix.com/GPX/1/0/gpx.xsd\">\n");y=y+i;
+  i= sprintf(&bufferTx[y],"  <trk>\n");y=y+i;
+  i= sprintf(&bufferTx[y],"    <trkseg>\n");y=y+i;
   file.write((const uint8_t *)&bufferTx,y);
   } 
 if(part==GPX_FRAME){  
@@ -65,21 +65,21 @@ if(part==GPX_FRAME){
       minute=ubxMessage.navPvt.minute;
       sec=ubxMessage.navPvt.second;
       y=0;
-      i= sprintf(bufferTx,"<trkpt lat=\"%.7f\" lon=\"%.7f\">",lat,lon);y=y+i;
-      i= sprintf(&bufferTx[y],"<ele>%.0f</ele>",msl);y=y+i;//was float !!!
-      i= sprintf(&bufferTx[y],"<time>%d-%'02d-%'02dT%'02d:%'02d:%'02dZ</time>",year,month,day,hour,minute,sec);y=y+i;
-      i= sprintf(&bufferTx[y],"<course>%.0f</course>",course);y=y+i;
-      i= sprintf(&bufferTx[y],"<speed>%.2f</speed>",speed);y=y+i;
-      i= sprintf(&bufferTx[y],"<sat>%d</sat>",sat);y=y+i;
-      i= sprintf(&bufferTx[y],"<hdop>%.2f</hdop>",hdop);y=y+i;
-      i= sprintf(&bufferTx[y],"</trkpt>\n");y=y+i;
+      i= sprintf(bufferTx,"      <trkpt lat=\"%.7f\" lon=\"%.7f\">",lat,lon);y=y+i;
+      i= sprintf(&bufferTx[y],"        <ele>%.0f</ele>",msl);y=y+i;//was float !!!
+      i= sprintf(&bufferTx[y],"        <time>%d-%'02d-%'02dT%'02d:%'02d:%'02dZ</time>",year,month,day,hour,minute,sec);y=y+i;
+      i= sprintf(&bufferTx[y],"        <course>%.0f</course>",course);y=y+i;
+      i= sprintf(&bufferTx[y],"        <speed>%.2f</speed>",speed);y=y+i;
+      i= sprintf(&bufferTx[y],"        <sat>%d</sat>",sat);y=y+i;
+      i= sprintf(&bufferTx[y],"        <hdop>%.2f</hdop>",hdop);y=y+i;
+      i= sprintf(&bufferTx[y],"      </trkpt>\n");y=y+i;
       file.write((const uint8_t *)&bufferTx,y);
       }
     }
   if(part==GPX_END){
      y=0;
-     i=sprintf(bufferTx,"</trkseg>\n");y=y+i;
-     i=sprintf(&bufferTx[y],"</trk>\n");y=y+i;
+     i=sprintf(bufferTx,"    </trkseg>\n");y=y+i;
+     i=sprintf(&bufferTx[y],"  </trk>\n");y=y+i;
      i=sprintf(&bufferTx[y],"</gpx>\n");y=y+i;
      file.write((const uint8_t *)&bufferTx,y);
      }      


### PR DESCRIPTION
I was just looking at the code that creates a GPX log file and noticed the absence of indentation.

I've made the following simple edits to gpx.h:

- Consolidate `<gpx>` onto a single line, multiple lines are mainly for tutorials
- Use the HTTPS location of the XSD, noting the namespace should stay as HTTP
- Added indentation to elements within `<gpx>`, using two tabs which is standard